### PR TITLE
Remove date from feature-header.

### DIFF
--- a/partials/feature-header.hbs
+++ b/partials/feature-header.hbs
@@ -13,7 +13,7 @@
     <div class='small-12 medium-8 medium-offset-2 columns header--feature__title-box'>
       <span class='header--feature__tag-bar'>{{tags separator=", "}}</span>
       <h1 class='header--feature__heading'>{{title}}</h1> 
-      {{#is "post"}}<div class='header--feature__metadata-bar'>{{t "By"}} {{author}} &middot; <time datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMM YYYY"}}</time></div>{{/is}}
+      {{#is "post"}}<div class='header--feature__metadata-bar'>{{t "By"}} {{author}}</div>{{/is}}
     </div>
   </div>
 </header>


### PR DESCRIPTION
We should remove dates from all blog posts, because the majority of content isn't time sensitive.