### PR TITLE
Remove timestamps from all posts types.

### DIFF
--- a/custom-bookreview.hbs
+++ b/custom-bookreview.hbs
@@ -8,7 +8,7 @@
       <section class='post-page-header'>
       <span class='post-page-header__tag-bar'>{{tags separator=", "}}</span>
       <h1 class="post-page-header__title">{{title}}</h1>
-      <div class='post-page-header__metadata-bar'>{{t "By"}} {{author}} &middot; <time datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMM YYYY"}}</time></div>
+      <div class='post-page-header__metadata-bar'>{{t "By"}} {{author}}</div>
       {{#if feature_image}}<img class='book-review__img' src='{{img_url feature_image}}'/>{{/if}}
       </section>
       <section class='post-page-content'>

--- a/partials/feature-header.hbs
+++ b/partials/feature-header.hbs
@@ -21,7 +21,7 @@
     <div class='small-12 medium-8 medium-offset-2 columns header--feature__title-box'>
       <span class='header--feature__tag-bar'>{{tags separator=", "}}</span>
       <h1 class='header--feature__heading'>{{title}}</h1> 
-      {{#is "post"}}<div class='header--feature__metadata-bar'>{{t "By"}} {{author}} &middot; <time datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMM YYYY"}}</time></div>{{/is}}
+      {{#is "post"}}<div class='header--feature__metadata-bar'>{{t "By"}} {{author}}</div>{{/is}}
     </div>
   </div>
 </header>

--- a/post.hbs
+++ b/post.hbs
@@ -6,7 +6,7 @@
       <section class='post-page-header'>
       <span class='post-page-header__tag-bar'>{{tags separator=", "}}</span>
       <h1 class="post-page-header__title">{{title}}</h1>
-      <div class='post-page-header__metadata-bar'>{{t "By"}} {{author}} &middot; <time datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMM YYYY"}}</time></div>
+      <div class='post-page-header__metadata-bar'>{{t "By"}} {{author}}</div>
       {{#if feature_image}}<img src='{{img_url feature_image}}' alt='{{t "Feature image for"}} {{title}}'/>{{/if}}
       </section>
       <section class='post-page-content'>


### PR DESCRIPTION
We should remove dates from all blog posts, because the majority of content isn't time sensitive.